### PR TITLE
Fix: Add email field support to registration API

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -68,6 +68,7 @@ class AuthController extends Controller
         $user = User::create([
             'name' => $request->name,
             'phone' => $request->phone,
+            'email' => $request->email,
             'password' => Hash::make($request->password),
             'accepted_terms' => true,
             'type' => 'public',
@@ -84,6 +85,7 @@ class AuthController extends Controller
                     'id' => $user->id,
                     'name' => $user->name,
                     'phone' => $user->phone,
+                    'email' => $user->email,
                     'type' => $user->type_label,
                     'status' => $user->status_label,
                 ],

--- a/app/Http/Requests/Api/RegisterRequest.php
+++ b/app/Http/Requests/Api/RegisterRequest.php
@@ -26,6 +26,7 @@ class RegisterRequest extends FormRequest
         return [
             'name' => 'required|string|max:255',
             'phone' => 'required|string|unique:users,phone',
+            'email' => 'nullable|string|email|max:255|unique:users,email',
             'password' => 'required|string|min:6',
             'password_confirmation' => 'required|same:password',
             'accepted_terms' => 'required|boolean|accepted',
@@ -44,6 +45,8 @@ class RegisterRequest extends FormRequest
             'name.max' => 'El nombre no puede exceder 255 caracteres.',
             'phone.required' => 'El número de teléfono es requerido.',
             'phone.unique' => 'El número de teléfono ya está registrado.',
+            'email.email' => 'El email debe tener un formato válido.',
+            'email.unique' => 'El email ya está registrado.',
             'password.required' => 'La contraseña es requerida.',
             'password.min' => 'La contraseña debe tener al menos 6 caracteres.',
             'password_confirmation.required' => 'La confirmación de contraseña es requerida.',

--- a/database/migrations/2025_08_13_005125_make_email_nullable_in_users_table.php
+++ b/database/migrations/2025_08_13_005125_make_email_nullable_in_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('email')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('email')->nullable(false)->change();
+        });
+    }
+};

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# RomanOcc Web - Development Server Startup Script
+# Usage: ./start.sh
+
+set -e
+
+echo "🚀 Starting RomanOcc Web Development Server..."
+echo "=============================================="
+
+# Check if we're in the right directory
+if [ ! -f "artisan" ]; then
+    echo "❌ Error: artisan file not found. Make sure you're in the Laravel project root."
+    exit 1
+fi
+
+# Check if PHP 8.3+ is available
+PHP_VERSION=$(php -v | head -n 1 | cut -d' ' -f2 | cut -d'.' -f1,2)
+REQUIRED_VERSION="8.3"
+
+if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$PHP_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+    echo "❌ Error: PHP $REQUIRED_VERSION+ required, but found PHP $PHP_VERSION"
+    echo "💡 Run: phpuse 8.3"
+    exit 1
+fi
+
+echo "✅ PHP version: $(php -v | head -n 1 | cut -d' ' -f2)"
+
+# Check if MySQL is running
+if ! /Applications/XAMPP/xamppfiles/bin/mysql -u root -p'N0m3l0s3#1' -e "SELECT 1;" >/dev/null 2>&1; then
+    echo "⚠️  Warning: MySQL not running. Starting MySQL..."
+    /Applications/XAMPP/xamppfiles/bin/mysql.server start >/dev/null 2>&1 || {
+        echo "❌ Error: Could not start MySQL. Please start it manually from XAMPP."
+        exit 1
+    }
+    echo "✅ MySQL started"
+else
+    echo "✅ MySQL is running"
+fi
+
+# Check if .env exists
+if [ ! -f ".env" ]; then
+    echo "❌ Error: .env file not found. Please copy .env.example to .env and configure it."
+    exit 1
+fi
+
+# Check if vendor directory exists
+if [ ! -d "vendor" ]; then
+    echo "📦 Installing Composer dependencies..."
+    composer install --no-interaction
+fi
+
+# Check if node_modules exists
+if [ ! -d "node_modules" ]; then
+    echo "📦 Installing NPM dependencies..."
+    npm install
+fi
+
+# Build assets if needed
+if [ ! -f "public/build/manifest.json" ]; then
+    echo "🔨 Building frontend assets..."
+    npm run build
+fi
+
+# Run migrations if needed
+echo "🗄️  Checking database migrations..."
+php artisan migrate --force
+
+echo ""
+echo "🌐 Starting development server..."
+echo "📍 URL: http://localhost:8000"
+echo "📍 Network: http://0.0.0.0:8000"
+echo "🛑 Press Ctrl+C to stop"
+echo ""
+
+# Start the development server
+php artisan serve --host=0.0.0.0 --port=8000


### PR DESCRIPTION

   ```markdown
   ## Cambios realizados
   
   - ✅ Añadido soporte para campo `email` en el registro de usuarios
   - ✅ Actualizada validación en `RegisterRequest` para incluir email
   - ✅ Modificado `AuthController` para procesar el campo email
   - ✅ Creada migración para hacer el campo email nullable
   - ✅ Añadido script `start.sh` para facilitar el desarrollo
   
   ## Formato JSON actualizado para registro:
   ```json
   {
       "name": "Usuario",
       "phone": "1234567890",
       "email": "1234567890@romanocc.com",
       "password": "123456",
       "password_confirmation": "123456",
       "accepted_terms": true
   }
   ```
   
   ## Problema resuelto
   - El frontend enviaba email pero el backend no lo procesaba
   - La tabla users tenía email como NOT NULL sin valor por defecto
   - Ahora el registro funciona correctamente con email opcional
   ```